### PR TITLE
Create Tech Stack docs

### DIFF
--- a/techstack.md
+++ b/techstack.md
@@ -1,0 +1,66 @@
+<!--
+--- Readme.md Snippet without images Start ---
+## Tech Stack
+spryker-community/LeanPublisher is built on the following main stack:
+- [PHP](http://www.php.net/) – Languages
+- [GitHub Actions](https://github.com/features/actions) – Continuous Integration
+
+Full tech stack [here](/techstack.md)
+--- Readme.md Snippet without images End ---
+
+--- Readme.md Snippet with images Start ---
+## Tech Stack
+spryker-community/LeanPublisher is built on the following main stack:
+- <img width='25' height='25' src='https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg' alt='PHP'/> [PHP](http://www.php.net/) – Languages
+- <img width='25' height='25' src='https://img.stackshare.io/service/11563/actions.png' alt='GitHub Actions'/> [GitHub Actions](https://github.com/features/actions) – Continuous Integration
+
+Full tech stack [here](/techstack.md)
+--- Readme.md Snippet with images End ---
+-->
+<div align="center">
+
+# Tech Stack File
+![](https://img.stackshare.io/repo.svg "repo") [spryker-community/LeanPublisher](https://github.com/spryker-community/LeanPublisher)![](https://img.stackshare.io/public_badge.svg "public")
+<br/><br/>
+|3<br/>Tools used|11/09/23 <br/>Report generated|
+|------|------|
+</div>
+
+## <img src='https://img.stackshare.io/languages.svg'/> Languages (1)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg' alt='PHP'>
+  <br>
+  <sub><a href="http://www.php.net/">PHP</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+## <img src='https://img.stackshare.io/devops.svg'/> DevOps (2)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/1046/git.png' alt='Git'>
+  <br>
+  <sub><a href="http://git-scm.com/">Git</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+<td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/11563/actions.png' alt='GitHub Actions'>
+  <br>
+  <sub><a href="https://github.com/features/actions">GitHub Actions</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+<br/>
+<div align='center'>
+
+Generated via [Stack File](https://github.com/apps/stack-file)

--- a/techstack.md
+++ b/techstack.md
@@ -26,7 +26,7 @@ Full tech stack [here](/techstack.md)
 # Tech Stack File
 ![](https://img.stackshare.io/repo.svg "repo") [spryker-community/LeanPublisher](https://github.com/spryker-community/LeanPublisher)![](https://img.stackshare.io/public_badge.svg "public")
 <br/><br/>
-|8<br/>Tools used|12/14/23 <br/>Report generated|
+|8<br/>Tools used|01/04/24 <br/>Report generated|
 |------|------|
 </div>
 

--- a/techstack.md
+++ b/techstack.md
@@ -26,7 +26,7 @@ Full tech stack [here](/techstack.md)
 # Tech Stack File
 ![](https://img.stackshare.io/repo.svg "repo") [spryker-community/LeanPublisher](https://github.com/spryker-community/LeanPublisher)![](https://img.stackshare.io/public_badge.svg "public")
 <br/><br/>
-|8<br/>Tools used|01/04/24 <br/>Report generated|
+|8<br/>Tools used|01/05/24 <br/>Report generated|
 |------|------|
 </div>
 

--- a/techstack.md
+++ b/techstack.md
@@ -1,28 +1,32 @@
 <!--
---- Readme.md Snippet without images Start ---
+&lt;--- Readme.md Snippet without images Start ---&gt;
 ## Tech Stack
 spryker-community/LeanPublisher is built on the following main stack:
+
 - [PHP](http://www.php.net/) – Languages
 - [GitHub Actions](https://github.com/features/actions) – Continuous Integration
 
 Full tech stack [here](/techstack.md)
---- Readme.md Snippet without images End ---
 
---- Readme.md Snippet with images Start ---
+&lt;--- Readme.md Snippet without images End ---&gt;
+
+&lt;--- Readme.md Snippet with images Start ---&gt;
 ## Tech Stack
 spryker-community/LeanPublisher is built on the following main stack:
+
 - <img width='25' height='25' src='https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg' alt='PHP'/> [PHP](http://www.php.net/) – Languages
 - <img width='25' height='25' src='https://img.stackshare.io/service/11563/actions.png' alt='GitHub Actions'/> [GitHub Actions](https://github.com/features/actions) – Continuous Integration
 
 Full tech stack [here](/techstack.md)
---- Readme.md Snippet with images End ---
+
+&lt;--- Readme.md Snippet with images End ---&gt;
 -->
 <div align="center">
 
 # Tech Stack File
 ![](https://img.stackshare.io/repo.svg "repo") [spryker-community/LeanPublisher](https://github.com/spryker-community/LeanPublisher)![](https://img.stackshare.io/public_badge.svg "public")
 <br/><br/>
-|3<br/>Tools used|11/09/23 <br/>Report generated|
+|8<br/>Tools used|12/14/23 <br/>Report generated|
 |------|------|
 </div>
 
@@ -60,7 +64,20 @@ Full tech stack [here](/techstack.md)
 </tr>
 </table>
 
+
+## <img src='https://img.stackshare.io/group.svg' /> Open source packages (5)</h2>
+
+## <img width='24' height='24' src='https://img.stackshare.io/package_manager/1778/default_90cb8b66e85ae5b95928b10bb076ab6a27c7e151.png'/> Packagist (5)
+
+|NAME|VERSION|LAST UPDATED|LAST UPDATED BY|LICENSE|VULNERABILITIES|
+|:------|:------|:------|:------|:------|:------|
+|[spryker/event](https://packagist.org/spryker/event)|v2.9|03/14/23|David Greiner |N/A|N/A|
+|[spryker/kernel](https://packagist.org/spryker/kernel)|v3.65|03/14/23|David Greiner |N/A|N/A|
+|[spryker/propel](https://packagist.org/spryker/propel)|v3.34|03/14/23|David Greiner |N/A|N/A|
+|[spryker/storage](https://packagist.org/spryker/storage)|v3.18|03/14/23|David Greiner |N/A|N/A|
+|[spryker/util-encoding](https://packagist.org/spryker/util-encoding)|v2.1|03/14/23|David Greiner |N/A|N/A|
+
 <br/>
 <div align='center'>
 
-Generated via [Stack File](https://github.com/apps/stack-file)
+Generated via [Stack File](https://github.com/marketplace/stack-file)

--- a/techstack.yml
+++ b/techstack.yml
@@ -1,0 +1,39 @@
+repo_name: spryker-community/LeanPublisher
+report_id: 65407fc89636eda24557edf298bd0023
+repo_type: Public
+timestamp: '2023-11-09T17:23:02+00:00'
+requested_by: greinerdavid
+provider: github
+branch: main
+detected_tools_count: 3
+tools:
+- name: PHP
+  description: A popular general-purpose scripting language that is especially suited
+    to web development
+  website_url: http://www.php.net/
+  open_source: true
+  hosted_saas: false
+  category: Languages & Frameworks
+  sub_category: Languages
+  image_url: https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg
+  detection_source: Repo Metadata
+- name: Git
+  description: Fast, scalable, distributed revision control system
+  website_url: http://git-scm.com/
+  open_source: true
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Version Control System
+  image_url: https://img.stackshare.io/service/1046/git.png
+  detection_source: Repo Metadata
+- name: GitHub Actions
+  description: Automate your workflow from idea to production
+  website_url: https://github.com/features/actions
+  open_source: false
+  hosted_saas: true
+  category: Build, Test, Deploy
+  sub_category: Continuous Integration
+  image_url: https://img.stackshare.io/service/11563/actions.png
+  detection_source: ".github/workflows/php.yml"
+  last_updated_by: David Greiner
+  last_updated_on: 2023-02-24 12:47:08.000000000 Z

--- a/techstack.yml
+++ b/techstack.yml
@@ -1,11 +1,11 @@
 repo_name: spryker-community/LeanPublisher
-report_id: 65407fc89636eda24557edf298bd0023
+report_id: e1c8ba0944691d6c952d0008989397bc
 repo_type: Public
-timestamp: '2023-11-09T17:23:02+00:00'
-requested_by: greinerdavid
+timestamp: '2023-12-14T09:51:34+00:00'
+requested_by: gxjansen
 provider: github
 branch: main
-detected_tools_count: 3
+detected_tools_count: 8
 tools:
 - name: PHP
   description: A popular general-purpose scripting language that is especially suited
@@ -37,3 +37,68 @@ tools:
   detection_source: ".github/workflows/php.yml"
   last_updated_by: David Greiner
   last_updated_on: 2023-02-24 12:47:08.000000000 Z
+- name: spryker/event
+  description: Event module
+  package_url: https://packagist.org/spryker/event
+  version: '2.9'
+  open_source: false
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Package Managers
+  image_url: https://img.stackshare.io/package/packagist/image.png
+  detection_source_url: https://github.com/spryker-community/LeanPublisher/blob/main/composer.json
+  detection_source: composer.json
+  last_updated_by: David Greiner
+  last_updated_on: 2023-03-14 15:10:41.000000000 Z
+- name: spryker/kernel
+  description: Kernel module
+  package_url: https://packagist.org/spryker/kernel
+  version: '3.65'
+  open_source: false
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Package Managers
+  image_url: https://img.stackshare.io/package/packagist/image.png
+  detection_source_url: https://github.com/spryker-community/LeanPublisher/blob/main/composer.json
+  detection_source: composer.json
+  last_updated_by: David Greiner
+  last_updated_on: 2023-03-14 15:10:41.000000000 Z
+- name: spryker/propel
+  description: Propel module
+  package_url: https://packagist.org/spryker/propel
+  version: '3.34'
+  open_source: false
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Package Managers
+  image_url: https://img.stackshare.io/package/packagist/image.png
+  detection_source_url: https://github.com/spryker-community/LeanPublisher/blob/main/composer.json
+  detection_source: composer.json
+  last_updated_by: David Greiner
+  last_updated_on: 2023-03-14 15:10:41.000000000 Z
+- name: spryker/storage
+  description: Storage module
+  package_url: https://packagist.org/spryker/storage
+  version: '3.18'
+  open_source: false
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Package Managers
+  image_url: https://img.stackshare.io/package/packagist/image.png
+  detection_source_url: https://github.com/spryker-community/LeanPublisher/blob/main/composer.json
+  detection_source: composer.json
+  last_updated_by: David Greiner
+  last_updated_on: 2023-03-14 15:10:41.000000000 Z
+- name: spryker/util-encoding
+  description: UtilEncoding module
+  package_url: https://packagist.org/spryker/util-encoding
+  version: '2.1'
+  open_source: false
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Package Managers
+  image_url: https://img.stackshare.io/package/packagist/image.png
+  detection_source_url: https://github.com/spryker-community/LeanPublisher/blob/main/composer.json
+  detection_source: composer.json
+  last_updated_by: David Greiner
+  last_updated_on: 2023-03-14 15:10:41.000000000 Z

--- a/techstack.yml
+++ b/techstack.yml
@@ -2,7 +2,7 @@ repo_name: spryker-community/LeanPublisher
 report_id: 65407fc89636eda24557edf298bd0023
 version: 0.1
 repo_type: Public
-timestamp: '2024-01-04T15:09:33+00:00'
+timestamp: '2024-01-05T09:11:20+00:00'
 requested_by: gxjansen
 provider: github
 branch: main

--- a/techstack.yml
+++ b/techstack.yml
@@ -1,7 +1,8 @@
 repo_name: spryker-community/LeanPublisher
-report_id: e1c8ba0944691d6c952d0008989397bc
+report_id: 65407fc89636eda24557edf298bd0023
+version: 0.1
 repo_type: Public
-timestamp: '2023-12-14T09:51:34+00:00'
+timestamp: '2024-01-04T15:09:33+00:00'
 requested_by: gxjansen
 provider: github
 branch: main
@@ -16,6 +17,7 @@ tools:
   category: Languages & Frameworks
   sub_category: Languages
   image_url: https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg
+  detection_source_url: https://github.com/spryker-community/LeanPublisher
   detection_source: Repo Metadata
 - name: Git
   description: Fast, scalable, distributed revision control system
@@ -25,6 +27,7 @@ tools:
   category: Build, Test, Deploy
   sub_category: Version Control System
   image_url: https://img.stackshare.io/service/1046/git.png
+  detection_source_url: https://github.com/spryker-community/LeanPublisher
   detection_source: Repo Metadata
 - name: GitHub Actions
   description: Automate your workflow from idea to production
@@ -34,6 +37,7 @@ tools:
   category: Build, Test, Deploy
   sub_category: Continuous Integration
   image_url: https://img.stackshare.io/service/11563/actions.png
+  detection_source_url: https://github.com/spryker-community/LeanPublisher/blob/main/.github/workflows/php.yml
   detection_source: ".github/workflows/php.yml"
   last_updated_by: David Greiner
   last_updated_on: 2023-02-24 12:47:08.000000000 Z


### PR DESCRIPTION
PR to add tech stack documentation to allow anyone to easily see what is being used in this repo without digging through config files. Two files are being added: techstack.yml and techstack.md. The techstack.yml file contains data on all the tools being used in this repo. The techstack.md file is derived from the YML file and displays the tech stack data in Markdown.